### PR TITLE
Use AC_REQUIRE for BOOST_REQUIRE

### DIFF
--- a/config/plugin_rest.m4
+++ b/config/plugin_rest.m4
@@ -1,6 +1,8 @@
 AM_CONDITIONAL([WITH_MGMT_REST], true)
 AC_DEFINE(WITH_MGMT_REST)
 
+AC_REQUIRE([BOOST_REQUIRE])
+
 BOOST_REQUIRE([1.54], [HAVE_BOOST=false])
 if (test "$HAVE_BOOST" = "false"); then
   AC_ERROR("REST management plugin requires Boost")


### PR DESCRIPTION
This patch fixes the warning:

config/plugin_rest.m4:9: warning: AC_REQUIRE: `BOOST_REQUIRE' was
expanded before it was required, part of the PR #79
